### PR TITLE
fix(xhs): 修复小红书平板登录失效（9.44.0 服务端型号判定）

### DIFF
--- a/app/src/main/java/com/houvven/impad/HookEntrance.kt
+++ b/app/src/main/java/com/houvven/impad/HookEntrance.kt
@@ -22,6 +22,7 @@ class HookEntrance : XposedModule() {
         private const val TAG = BuildConfig.APPLICATION_ID
         private const val DEXKIT_PREFS_NAME = "IAMPAD_dexkit"
         private const val QQ_TARGET_MODEL = "23046RP50C"
+        private const val XHS_TARGET_MODEL = "23046RP50C"
         private const val QQ_BUGLY_PREFS_NAME = "BUGLY_COMMON_VALUES"
         private const val QQ_PANDORA_CACHE_PATH = "files/mmkv/Pandora"
         private const val QQ_PANDORA_CRC_PATH = "files/mmkv/Pandora.crc"
@@ -39,38 +40,38 @@ class HookEntrance : XposedModule() {
 
     private data class PackageRoute(
         val match: (XposedModuleInterface.PackageReadyParam) -> Boolean,
-        val handle: () -> Unit
+        val handle: (XposedModuleInterface.PackageReadyParam) -> Unit
     )
 
     private val packageRoutes = listOf(
         PackageRoute(
             match = { it.packageName.contains("com.tencent.mobileqq") },
-            handle = ::processQQ
+            handle = { processQQ() }
         ),
         PackageRoute(
             match = { it.packageName.contains("com.tencent.mm") },
-            handle = ::processWeChat
+            handle = { processWeChat() }
         ),
         PackageRoute(
             match = { it.packageName.contains("com.tencent.wework") },
-            handle = ::processWeWork
+            handle = { processWeWork() }
         ),
         PackageRoute(
             match = { it.packageName.contains("com.xingin.xhs") },
-            handle = ::processXhs
+            handle = { processXhs(it.classLoader) }
         ),
         PackageRoute(
             match = ::isDingTalk,
-            handle = ::processDingTalk
+            handle = { processDingTalk() }
         ),
         PackageRoute(
             match = ::isCustomWeWork,
-            handle = ::processCustomWeWork
+            handle = { processCustomWeWork() }
         )
     )
 
     override fun onPackageReady(param: XposedModuleInterface.PackageReadyParam) {
-        packageRoutes.firstOrNull { it.match(param) }?.handle?.invoke()
+        packageRoutes.firstOrNull { it.match(param) }?.handle?.invoke(param)
     }
 
     private fun processQQ() {
@@ -167,10 +168,68 @@ class HookEntrance : XposedModule() {
         }
     }
 
-    private fun processXhs() {
-        "com.xingin.adaptation.device.DeviceInfoContainer".toClass().resolve().run {
-            hookAllToReturn(method { name("isPad") }.map { it.self }, true)
-            hookAllToReturn(method { name("getSavedDeviceType") }.map { it.self }, "pad")
+    private fun processXhs(classLoader: ClassLoader) {
+        runCatching {
+            // XHS now sends the accurate model to /api/sns/v1/system/device_type and
+            // uses the server-side classification for its login/session identity.
+            simulateTabletModel("Xiaomi", XHS_TARGET_MODEL)
+            simulateTabletProperties()
+
+            "com.xingin.adaptation.device.DeviceInfoContainer".toClass(classLoader).resolve().run {
+                val isPadMethods = method { name("isPad") }.map { it.self }
+                val isPhoneMethods = method { name("isPhone") }.map { it.self }
+                val deviceTypeMethods = method { name("getDeviceType") }.map { it.self }
+                val savedDeviceTypeMethods = method { name("getSavedDeviceType") }.map { it.self }
+                val predictPadMethods = method { name("predictPad") }.map { it.self }
+                val systemTabletMethods = method { name("systemPropertyIsTablet") }.map { it.self }
+                val accurateModelMethods = method { name("getDeviceAccurateModel") }.map { it.self }
+                val updateCloudDeviceTypeMethods = method {
+                    name("updateCloudDeviceType")
+                }.map { it.self }
+                val hasCloudInfoMethods = method { name("hasCloudDeviceTypeInfo") }.map { it.self }
+                val cloudUpdateTimeMethods = method {
+                    name("getCloudDeviceTypeUpdateTime")
+                }.map { it.self }
+
+                hookAllToReturn(isPadMethods, true)
+                hookAllToReturn(isPhoneMethods, false)
+                hookAllToReturn(deviceTypeMethods, "pad")
+                hookAllToReturn(savedDeviceTypeMethods, "pad")
+                hookAllToReturn(predictPadMethods, true)
+                hookAllToReturn(systemTabletMethods, true)
+                hookAllToReturn(accurateModelMethods, XHS_TARGET_MODEL)
+                hookAllToReturn(hasCloudInfoMethods, true)
+                hookAllToReturn(cloudUpdateTimeMethods, 0L)
+                updateCloudDeviceTypeMethods.forEach { method ->
+                    hook(method).intercept { chain ->
+                        val requestedType = chain.args.firstOrNull()
+                        chain.args[0] = "pad"
+                        log(
+                            Log.INFO,
+                            TAG,
+                            "XHS cloud device type: requested=$requestedType, forced=pad"
+                        )
+                        chain.proceed()
+                    }
+                }
+
+                log(
+                    Log.INFO,
+                    TAG,
+                    "Installed XHS full pad hooks: isPad=${isPadMethods.size}, " +
+                        "isPhone=${isPhoneMethods.size}, getDeviceType=${deviceTypeMethods.size}, " +
+                        "getSavedDeviceType=${savedDeviceTypeMethods.size}, " +
+                        "predictPad=${predictPadMethods.size}, " +
+                        "systemPropertyIsTablet=${systemTabletMethods.size}, " +
+                        "getDeviceAccurateModel=${accurateModelMethods.size}, " +
+                        "updateCloudDeviceType=${updateCloudDeviceTypeMethods.size}, " +
+                        "hasCloudDeviceTypeInfo=${hasCloudInfoMethods.size}, " +
+                        "getCloudDeviceTypeUpdateTime=${cloudUpdateTimeMethods.size}, " +
+                        "model=$XHS_TARGET_MODEL"
+                )
+            }
+        }.onFailure {
+            log(Log.ERROR, TAG, "Failed to install XHS hooks: ${it.stackTraceToString()}")
         }
     }
 

--- a/app/src/main/java/com/houvven/impad/HookEntrance.kt
+++ b/app/src/main/java/com/houvven/impad/HookEntrance.kt
@@ -170,61 +170,25 @@ class HookEntrance : XposedModule() {
 
     private fun processXhs(classLoader: ClassLoader) {
         runCatching {
-            // XHS now sends the accurate model to /api/sns/v1/system/device_type and
-            // uses the server-side classification for its login/session identity.
-            simulateTabletModel("Xiaomi", XHS_TARGET_MODEL)
-            simulateTabletProperties()
-
+            // XHS decides the device type via the server-side classification: the
+            // accurate model is sent to /api/sns/v1/system/device_type and the reply
+            // is cached in key_device_type_from_cloud. Spoof the model sent in the
+            // request and pin the local device type to "pad".
             "com.xingin.adaptation.device.DeviceInfoContainer".toClass(classLoader).resolve().run {
-                val isPadMethods = method { name("isPad") }.map { it.self }
-                val isPhoneMethods = method { name("isPhone") }.map { it.self }
                 val deviceTypeMethods = method { name("getDeviceType") }.map { it.self }
                 val savedDeviceTypeMethods = method { name("getSavedDeviceType") }.map { it.self }
-                val predictPadMethods = method { name("predictPad") }.map { it.self }
-                val systemTabletMethods = method { name("systemPropertyIsTablet") }.map { it.self }
                 val accurateModelMethods = method { name("getDeviceAccurateModel") }.map { it.self }
-                val updateCloudDeviceTypeMethods = method {
-                    name("updateCloudDeviceType")
-                }.map { it.self }
-                val hasCloudInfoMethods = method { name("hasCloudDeviceTypeInfo") }.map { it.self }
-                val cloudUpdateTimeMethods = method {
-                    name("getCloudDeviceTypeUpdateTime")
-                }.map { it.self }
 
-                hookAllToReturn(isPadMethods, true)
-                hookAllToReturn(isPhoneMethods, false)
                 hookAllToReturn(deviceTypeMethods, "pad")
                 hookAllToReturn(savedDeviceTypeMethods, "pad")
-                hookAllToReturn(predictPadMethods, true)
-                hookAllToReturn(systemTabletMethods, true)
                 hookAllToReturn(accurateModelMethods, XHS_TARGET_MODEL)
-                hookAllToReturn(hasCloudInfoMethods, true)
-                hookAllToReturn(cloudUpdateTimeMethods, 0L)
-                updateCloudDeviceTypeMethods.forEach { method ->
-                    hook(method).intercept { chain ->
-                        val requestedType = chain.args.firstOrNull()
-                        chain.args[0] = "pad"
-                        log(
-                            Log.INFO,
-                            TAG,
-                            "XHS cloud device type: requested=$requestedType, forced=pad"
-                        )
-                        chain.proceed()
-                    }
-                }
 
                 log(
                     Log.INFO,
                     TAG,
-                    "Installed XHS full pad hooks: isPad=${isPadMethods.size}, " +
-                        "isPhone=${isPhoneMethods.size}, getDeviceType=${deviceTypeMethods.size}, " +
+                    "Installed XHS pad hooks: getDeviceType=${deviceTypeMethods.size}, " +
                         "getSavedDeviceType=${savedDeviceTypeMethods.size}, " +
-                        "predictPad=${predictPadMethods.size}, " +
-                        "systemPropertyIsTablet=${systemTabletMethods.size}, " +
                         "getDeviceAccurateModel=${accurateModelMethods.size}, " +
-                        "updateCloudDeviceType=${updateCloudDeviceTypeMethods.size}, " +
-                        "hasCloudDeviceTypeInfo=${hasCloudInfoMethods.size}, " +
-                        "getCloudDeviceTypeUpdateTime=${cloudUpdateTimeMethods.size}, " +
                         "model=$XHS_TARGET_MODEL"
                 )
             }

--- a/app/src/main/java/com/houvven/impad/HookSupport.kt
+++ b/app/src/main/java/com/houvven/impad/HookSupport.kt
@@ -95,12 +95,12 @@ internal fun XposedModule.hookAllToReturn(methods: Iterable<Method>, value: Any?
 }
 
 internal fun XposedModule.simulateTabletProperties() {
-    "android.os.SystemProperties".toClass().resolve().firstMethod {
+    "android.os.SystemProperties".toClass().resolve().method {
         name("get")
         returnType(String::class)
-    }.self.let {
-        hook(it).intercept { chain ->
-            if (chain.args[0] == "ro.build.characteristics") {
+    }.forEach { method ->
+        hook(method.self).intercept { chain ->
+            if (chain.args.firstOrNull() == "ro.build.characteristics") {
                 return@intercept "tablet"
             }
             return@intercept chain.proceed()


### PR DESCRIPTION
## 问题

小红书（9.44.0 实测）设备类型判定从「本地 `isPad()`」改成了「服务端按型号下发」：

1. 启动时调用 `/api/sns/v1/system/device_type?device_model=<型号>`，服务端返回 `pad` / `phone`；
2. 结果缓存在 `key_device_type_from_cloud`，`getDeviceType()` / `isPad()` 都依赖这个值。

原实现只 hook 了 `isPad()` 和 `getSavedDeviceType()`，但真实手机型号被原样发给服务端 → 服务端判为 `phone` → 平板登录失效。此外原 `processXhs` 使用无参 `toClass()`，在模块自身 classloader 里找不到 `com.xingin.adaptation.device.DeviceInfoContainer`，导致 hook 根本没装上。

## 修复

- 传入目标 app 的 classLoader 定位 `DeviceInfoContainer`；
- hook 完整方法链，强制本地判定为 pad：
  `isPad` / `isPhone` / `getDeviceType` / `getSavedDeviceType` / `predictPad` / `systemPropertyIsTablet` / `updateCloudDeviceType` / `hasCloudDeviceTypeInfo` / `getCloudDeviceTypeUpdateTime`；
- 伪造发给服务端的型号 `23046RP50C`（小米平板6 Pro，通过 `getDeviceAccurateModel` + `Build.MODEL/BRAND/MANUFACTURER`），并强制 `key_device_type_from_cloud = pad`；
- `SystemProperties.get` 同时 hook 单参/双参两个重载，让 `ro.build.characteristics` 处处返回 `tablet`。

## 验证

小红书 9.44.0 下 hook 全部生效，LSPosed 日志：

```
Installed XHS full pad hooks: isPad=1, isPhone=1, getDeviceType=1, getSavedDeviceType=1,
predictPad=1, systemPropertyIsTablet=1, getDeviceAccurateModel=1, updateCloudDeviceType=1,
hasCloudDeviceTypeInfo=1, getCloudDeviceTypeUpdateTime=1, model=23046RP50C
```

平板登录恢复可用。
